### PR TITLE
Fix error related to unknown :skill and profile.id.nil

### DIFF
--- a/backend/app/controllers/dashboards_controller.rb
+++ b/backend/app/controllers/dashboards_controller.rb
@@ -4,7 +4,7 @@ class DashboardsController < ApplicationController
   def index
     @user = find_user(current_user.id)
     @profile = find_hunter_profile(@user.id) unless @user.nil?
-    @listings = find_hunter_matches(@profile.id)
+    @listings = find_hunter_matches(@profile.id) unless @profile.nil?
   end
 
   def online?

--- a/backend/app/models/hunter_profile.rb
+++ b/backend/app/models/hunter_profile.rb
@@ -1,6 +1,6 @@
 class HunterProfile < ApplicationRecord
   belongs_to :user, :foreign_key => "user_id"
   has_many :hunter_profiles_skills
-  has_many :skill, through :hunter_profiles_skills
-  accepts_nested_attributes_for :skill, :allow_destroy => true
+  has_many :skills, :through => :hunter_profiles_skills
+  accepts_nested_attributes_for :skills, :allow_destroy => true
 end


### PR DESCRIPTION
    - Listings returned to the dashboard were dependent on finding the profile.id, but if there is not profile, then it will be nul
    - Now only returns profile.id if profile.nil? is false
    - also finds :skills, :through => :hunter_profile_id