### PR TITLE
Change skills relation to be more accesible

### DIFF
--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -94,12 +94,18 @@ class ApplicationController < ActionController::Base
     elsif dist < 20000
       score += 5
     end
-    # increment scoring based on skills
-
+    # increment scoring based on skills that match
+    # TODO make this matching take into account
+    # => if a listing has < 5 skills required.
+    # => Skills should always account for 50% of the score
+    score += (hunter.skills & listing.skills).count * 10
   end
 
   # return the max_score available
   def max_score(listing)
+    # TODO make this matching take into account
+    # => if a listing has < 5 skills required.
+    # => Skills should always account for 50% of the score
     10 * listing.skills.count + # 10 for each skill
     25 +  # hours
     25    # location; Smaller the distance, higher the score

--- a/backend/app/models/hunter_profile.rb
+++ b/backend/app/models/hunter_profile.rb
@@ -1,9 +1,8 @@
 class HunterProfile < ApplicationRecord
   belongs_to :user, :foreign_key => "user_id"
-  has_many :skills, :through => :hunter_profiles_skills
+  has_and_belongs_to_many :skills, :through => :hunter_profiles_skills
   accepts_nested_attributes_for :skills, :allow_destroy => true
 
   has_and_belongs_to_many :listings, :through => :hunter_profiles_listings
-
 
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -9,13 +9,11 @@ class User < ApplicationRecord
 
   def is_employer?
     #   # return true iff the employer table has a reference to this user's ID
-    if current_user
-      if current_user.employer_profile
-        true
-      end
+    if User.find(self.id).employer_profile
+      true
     end
   end
-
+  
   def self.current
     Thread.current[:user]
   end

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -5,6 +5,35 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+skills = Skill.create(
+  [
+    {
+      name: 'C',
+      industry: 'SoftEng'
+    },
+    {
+      name: 'Java',
+      industry: 'SoftEng'
+    },
+    {
+      name: 'C++',
+      industry: 'SoftEng'
+    },
+    {
+      name: 'Ruby on Rails',
+      industry: 'WebDev'
+    },
+    {
+      name: 'Bartender',
+      industry: 'Hospitality'
+    },
+    {
+      name: 'Customer Service',
+      industry: 'Customer Service'
+    }
+  ]
+)
+
 users = User.create(
   [
     {
@@ -44,13 +73,15 @@ hunters = HunterProfile.create(
       user: users.first,
       min_salary: 23.7,
       location: 'Melbourne CBD',
-      hours: 'Full Time'
+      hours: 'Full Time',
+      skills: [skills[0], skills[1]]
     },
     {
       user: users.second,
       min_salary: 23.7,
       location: 'Melbourne CBD',
-      hours: 'Full Time'
+      hours: 'Full Time',
+      skills: [skills[0], skills[5], skills[4]]
     }
   ]
 )
@@ -70,31 +101,6 @@ employers = EmployerProfile.create(
   ]
 )
 
-Skill.create(
-  [
-    {
-      id: 1,
-      name: 'C',
-      industry: 'SoftEng'
-    },
-    {
-      id: 2,
-      name: 'Java',
-      industry: 'SoftEng'
-    },
-    {
-      id: 7,
-      name: 'C++',
-      industry: 'SoftEng'
-    },
-    {
-      id: 4,
-      name: 'Ruby on Rails',
-      industry: 'WebDev'
-    }
-  ]
-)
-
 listings = Listing.create(
   [
     {
@@ -106,7 +112,7 @@ listings = Listing.create(
       min_salary: 25.5,
       hours: 'Full Time',
       employer_profile: employers.second,
-      skills: [Skill.first, Skill.second]
+      skills: [skills[0], skills[1], skills[5]]
     },
     {
       title: 'C# Programmer',
@@ -117,7 +123,7 @@ listings = Listing.create(
       min_salary: 38.2,
       hours: 'Contract',
       employer_profile: employers.first,
-      skills: []
+      skills: [skills[0], skills[2]]
     },
     {
       title: 'Kitchen Hand',
@@ -128,7 +134,7 @@ listings = Listing.create(
       min_salary: 15.2,
       hours: 'Part Time',
       employer_profile: employers.first,
-      skills: []
+      skills: [skills[5], skills[4]]
     }
   ]
 )


### PR DESCRIPTION
    - Skills for  a user's profile can be obtained via User.hunter_profile.skills
    - Skills for a listing can be obtained via Listing.skills
    - These can be compared using array1 & array2 to get a count of how many skills the hunter has for the listing